### PR TITLE
add profile detail page

### DIFF
--- a/client/src/components/ProfileDetail/ProfileDetail.tsx
+++ b/client/src/components/ProfileDetail/ProfileDetail.tsx
@@ -12,7 +12,6 @@ const ProfileDetail = (): JSX.Element => {
     return profile.accountType === 'pet_owner' ? 'Kind pet owner' : 'Loving pet sitter';
   };
 
-  console.log(profile);
   return profile ? (
     <Paper elevation={8} className={classes.paper}>
       <Grid container direction="column">

--- a/client/src/components/ProfileDetail/ProfileDetail.tsx
+++ b/client/src/components/ProfileDetail/ProfileDetail.tsx
@@ -1,0 +1,58 @@
+import { Avatar, Card, CircularProgress, Grid, Paper, Typography } from '@mui/material';
+import { useAuth } from '../../context/useAuthContext';
+import React from 'react';
+import { useStyles } from './useStyles';
+import { LocationOn } from '@mui/icons-material';
+
+const ProfileDetail = (): JSX.Element => {
+  const classes = useStyles();
+  const { profile } = useAuth();
+
+  const title = () => {
+    return profile.accountType === 'pet_owner' ? 'Kind pet owner' : 'Loving pet sitter';
+  };
+
+  console.log(profile);
+  return profile ? (
+    <Paper elevation={8} className={classes.paper}>
+      <Grid container direction="column">
+        <Grid item>
+          <img
+            className={classes.userBackground}
+            src="http://pic.616pic.com/bg_w1180/00/03/56/J9aghMknMg.jpg"
+            alt="user background"
+          />
+        </Grid>
+        <Grid item alignSelf="center">
+          <Avatar src={profile.photo} sx={{ width: 100, height: 100, border: 3 }} className={classes.avatar} />
+        </Grid>
+        <Grid item alignSelf="center">
+          <Typography variant="h4" className={classes.name} sx={{ fontWeight: 'bold' }}>
+            {profile.name}
+          </Typography>
+          <Typography variant="subtitle1" className={classes.name} sx={{ fontWeight: 'light' }}>
+            {title()}
+          </Typography>
+        </Grid>
+        <Grid item alignSelf="center">
+          <Typography variant="h6" sx={{ fontWeight: 'light' }}>
+            <LocationOn color="primary" />
+            {profile.address}
+          </Typography>
+        </Grid>
+        <Grid item display="flex" justifyContent="center">
+          <Card elevation={2} className={classes.descriptionCard}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+              About me
+            </Typography>
+            <Typography variant="body1">description</Typography>
+          </Card>
+        </Grid>
+      </Grid>
+    </Paper>
+  ) : (
+    <CircularProgress />
+  );
+};
+
+export default ProfileDetail;

--- a/client/src/components/ProfileDetail/useStyles.ts
+++ b/client/src/components/ProfileDetail/useStyles.ts
@@ -1,0 +1,30 @@
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  paper: {
+    marginTop: '2%',
+    marginLeft: '4%',
+    width: '60%',
+    borderRadius: '50%',
+  },
+  avatar: {
+    position: 'relative',
+    top: '-45px',
+    // padding: '5px',
+  },
+  userBackground: {
+    width: '100%',
+    borderRadius: '8px',
+  },
+  name: {
+    textAlign: 'center',
+    position: 'relative',
+    top: '-20px',
+  },
+  descriptionCard: {
+    margin: '20px',
+    width: '95%',
+    padding: '5px',
+  },
+}));

--- a/client/src/components/ProfileDetail/useStyles.ts
+++ b/client/src/components/ProfileDetail/useStyles.ts
@@ -11,7 +11,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
   avatar: {
     position: 'relative',
     top: '-45px',
-    // padding: '5px',
   },
   userBackground: {
     width: '100%',


### PR DESCRIPTION
### What this PR does (required):
- create profile detail page as mockup

### Screenshots / Videos (front-end only):
![image](https://user-images.githubusercontent.com/32376967/151906208-4973960b-7f89-405e-b436-f2e2d7d73bcb.png)

### Any information needed to test this feature (required):
- need to change the user background after that add to the user profile.
